### PR TITLE
Fix get_summary_bstate() for MDRG word policy

### DIFF
--- a/convlab/modules/word_policy/multiwoz/mdrg/policy.py
+++ b/convlab/modules/word_policy/multiwoz/mdrg/policy.py
@@ -239,12 +239,8 @@ def get_summary_bstate(bstate):
         if domain == 'train':
             if 'people' not in bstate[domain]['book'].keys():
                 booking.append(0)
-            else:
-                booking.append(1)
             if 'ticket' not in bstate[domain]['book'].keys():
                 booking.append(0)
-            else:
-                booking.append(1)
         summary_bstate += booking
 
         for slot in bstate[domain]['semi']:


### PR DESCRIPTION
ConvLab's version of `get_summary_bstate()` differs from [that of the original MultiWoZ repository](https://github.com/budzianowski/multiwoz/blob/6c0592944fc5976d525b145deeaebeee06bca40c/create_delex_data.py#L131) for the `train` domain. 

In the MultiWoZ version where the downloaded model is from, there is no append statement when 'people' or 'ticket' is not in the key, but in the ConvLab version there are. This makes `len(booking) == 95`, which triggers the assert statement. Fixing this resolves the `Response generation error`.

Fixes Question 3 of #48 

### ConvLab

`/convlab/modules/word_policy/multiwoz/mdrg/policy.py`

```python
def get_summary_bstate(bstate):
    """Based on the mturk annotations we form multi-domain belief state"""
    domains = ['taxi', 'restaurant', 'hospital', 'hotel', 'attraction', 'train', 'police']
    summary_bstate = []
    for domain in domains:
        domain_active = False

        ...

        if domain == 'train':
            if 'people' not in bstate[domain]['book'].keys():
                booking.append(0)
            else:
                booking.append(1)
            if 'ticket' not in bstate[domain]['book'].keys():
                booking.append(0)
            else:
                booking.append(1)
        summary_bstate += booking

        ...

    # pprint(summary_bstate)
    #print(len(summary_bstate))
    assert len(summary_bstate) == 94
    return summary_bstate
```

### MultiWoZ

`multiwoz/create_delex_data.py`

```python
def get_summary_bstate(bstate):
    """Based on the mturk annotations we form multi-domain belief state"""
    domains = [u'taxi',u'restaurant',  u'hospital', u'hotel',u'attraction', u'train', u'police']
    summary_bstate = []
    for domain in domains:
        domain_active = False

        ...

        if domain == 'train':
            if 'people' not in bstate[domain]['book'].keys():
                booking.append(0)
            if 'ticket' not in bstate[domain]['book'].keys():
                booking.append(0)
        summary_bstate += booking

        ...

    #print(len(summary_bstate))
    assert len(summary_bstate) == 94
    return summary_bstate
```
